### PR TITLE
Release mouse capture before setting drag mode.

### DIFF
--- a/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
+++ b/ICSharpCode.AvalonEdit/Editing/SelectionMouseHandler.cs
@@ -288,11 +288,11 @@ namespace ICSharpCode.AvalonEdit.Editing
 		
 		void StartDrag()
 		{
+			// mouse capture and Drag'n'Drop don't mix
+			textArea.ReleaseMouseCapture();
+
 			// prevent nested StartDrag calls
 			mode = MouseSelectionMode.Drag;
-			
-			// mouse capture and Drag'n'Drop doesn't mix
-			textArea.ReleaseMouseCapture();
 			
 			DataObject dataObject = textArea.Selection.CreateDataObject(textArea);
 			


### PR DESCRIPTION
The original code set the mode to Drag, then released mouse capture which in turn set the mode to None. After dropping the code selection, there is a check if the mode is set to Drag and that was where the dropping was failing.